### PR TITLE
[sdk] fallback to SDK environment variable.

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -177,7 +177,7 @@ namespace :ci do
 
     task :run_tests, [:flavor, :cihome, :mocked] do |t, attr|
       flavors = attr[:flavor]
-      cihome = attr[:cihome]
+      cihome = attr[:cihome] || "#{ENV['SDK_HOME']}/ci" || Dir.pwd
       mocked = attr[:mocked] || false
       filter = ENV['NOSE_FILTER'] || '1'
       nose_command = in_venv ? 'venv/bin/nosetests' : 'nosetests'


### PR DESCRIPTION
### What

If we don't set the attribute when calling `run_tests` we should fallback to the environment variable for the CI home.
