### PR TITLE
Fixing rakefile

### DIFF
--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -102,8 +102,8 @@ namespace :generate do
     sh "cp #{gem_home}/lib/config/README.md #{ENV['SDK_HOME']}/#{args[:option]}/README.md"
     sh "find #{ENV['SDK_HOME']}/#{args[:option]} -type f -exec sed -i '' \"s/skeleton/#{args[:option]}/g\" {} \\;"
     sh "find #{ENV['SDK_HOME']}/#{args[:option]} -type f -exec sed -i '' \"s/Skeleton/#{capitalized}/g\" {} \\;"
-    sh "sed -i '' \"s/skeleton/#{args[:option]}/g\" #{ENV['SDK_HOME']}/ci/#{args[:option]}.rake"
-    sh "sed -i '' \"s/Skeleton/#{capitalized}/g\" #{ENV['SDK_HOME']}/ci/#{args[:option]}.rake"
+    sh "sed -i \"s/skeleton/#{args[:option]}/g\" #{ENV['SDK_HOME']}/ci/#{args[:option]}.rake"
+    sh "sed -i \"s/Skeleton/#{capitalized}/g\" #{ENV['SDK_HOME']}/ci/#{args[:option]}.rake"
     sh "git add #{ENV['SDK_HOME']}/ci/#{args[:option]}.rake"
     sh "git add #{ENV['SDK_HOME']}/#{args[:option]}/*"
 


### PR DESCRIPTION
This was making the rake command fail with

```
sed -i '' "s/skeleton/redis/g" /home/vagrant/integrations-core/ci/redis.rake
sed: can't read s/skeleton/redis/g: No such file or directory
rake aborted!
Command failed with status (2): [sed -i '' "s/skeleton/redis/g" /home/vagra...]
/home/vagrant/.rvm/gems/ruby-2.3.0@goagent/gems/datadog-sdk-testing-0.1.1/lib/tasks/sdk.rake:105:in `block (2 levels) in <top (required)>'
/home/vagrant/.rvm/gems/ruby-2.3.0@goagent/gems/rake-11.2.2/exe/rake:27:in `<top (required)>'
/home/vagrant/.rvm/gems/ruby-2.3.0@goagent/bin/ruby_executable_hooks:15:in `eval'
/home/vagrant/.rvm/gems/ruby-2.3.0@goagent/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => generate:skeleton
```
