### PR TITLE
[sdk] moving the ci directory to be within the integration package.

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -12,6 +12,14 @@ def check_env
   abort 'SDK_HOME env variable must be defined in your Rakefile to used this gem.' unless ENV['SDK_HOME']
 end
 
+def sed(source, a, b, mods)
+  if RUBY_PLATFORM.include? 'darwin'
+    sh "sed -i '' \"s/#{a}/#{b}/#{mods}\" #{source}"
+  else
+    sh "sed -i \"s/#{a}/#{b}/#{mods}\" #{source}"
+  end
+end
+
 def sleep_for(secs)
   puts "Sleeping for #{secs}s".blue
   sleep(secs)

--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -102,10 +102,12 @@ namespace :generate do
     sh "cp #{gem_home}/lib/config/metadata.csv #{ENV['SDK_HOME']}/#{args[:option]}/metadata.csv"
     sh "cp #{gem_home}/lib/config/requirements.txt #{ENV['SDK_HOME']}/#{args[:option]}/requirements.txt"
     sh "cp #{gem_home}/lib/config/README.md #{ENV['SDK_HOME']}/#{args[:option]}/README.md"
-    sh "find #{ENV['SDK_HOME']}/#{args[:option]} -type f -exec sed -i '' \"s/skeleton/#{args[:option]}/g\" {} \\;"
-    sh "find #{ENV['SDK_HOME']}/#{args[:option]} -type f -exec sed -i '' \"s/Skeleton/#{capitalized}/g\" {} \\;"
-    sh "sed -i '' \"s/skeleton/#{args[:option]}/g\" #{ENV['SDK_HOME']}/#{args[:option]}/ci/#{args[:option]}.rake"
-    sh "sed -i '' \"s/Skeleton/#{capitalized}/g\" #{ENV['SDK_HOME']}/#{args[:option]}/ci/#{args[:option]}.rake"
+    Dir.glob("#{ENV['SDK_HOME']}/#{args[:option]}/**/*") do |f|
+      if File.file?(f)
+        sed(f, 'skeleton', "#{args[:option]}", 'g')
+        sed(f, 'Skeleton', "#{capitalized}", 'g')
+      end
+    end
     sh "git add #{ENV['SDK_HOME']}/#{args[:option]}/"
 
     new_file = "#{ENV['SDK_HOME']}/circle.yml.new"


### PR DESCRIPTION
Let's get rid of the `ci/` folder in the root of the `integrations-{core,extras}` dir - it looks ugly and exposes too much. This change will include the `ci/` folder in each of the integrations subdirs. If preferred, we can just remove the `ci/` folder altogether.

Next step, calling tests with `nose` if no rakefile exists.

Also fixing sed calls to be compatible with both GNU (linux) and BSD (OSX) seds.
