### PR TITLE
[gem] no such thing as ci_home anymore. Refactoring.

### DIFF
--- a/lib/config/ci/skeleton.rake
+++ b/lib/config/ci/skeleton.rake
@@ -25,12 +25,11 @@ namespace :ci do
     task before_script: ['ci:common:before_script']
 
     task :script, [:mocked] => ['ci:common:script'] do |_, attr|
-      ci_home = File.dirname(__FILE__)
       mocked = attr[:mocked] || false
       this_provides = [
         'skeleton'
       ]
-      Rake::Task['ci:common:run_tests'].invoke(this_provides, ci_home, mocked)
+      Rake::Task['ci:common:run_tests'].invoke(this_provides, mocked)
     end
 
     task before_cache: ['ci:common:before_cache']

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -57,8 +57,8 @@ def test_files(sdk_dir)
   end
 end
 
-def integration_tests(ci_dir)
-  sdk_dir = File.join(ci_dir, '..')
+def integration_tests(root_dir)
+  sdk_dir = ENV['SDK_HOME'] || root_dir
   integrations = []
   untested = []
   testable = []
@@ -183,9 +183,9 @@ namespace :ci do
       t.reenable
     end
 
-    task :run_tests, [:flavor, :cihome, :mocked] do |t, attr|
+    task :run_tests, [:flavor, :mocked] do |t, attr|
       flavors = attr[:flavor]
-      cihome = attr[:cihome] || "#{ENV['SDK_HOME']}/ci" || Dir.pwd
+      sdkhome = ENV['SDK_HOME'] || Dir.pwd
       mocked = attr[:mocked] || false
       filter = ENV['NOSE_FILTER'] || '1'
       nose_command = in_venv ? 'venv/bin/nosetests' : 'nosetests'
@@ -197,7 +197,7 @@ namespace :ci do
                "(requires in ['#{flavors.join("','")}']) and #{filter} and #{mock_filter}"
              end
 
-      tests_directory, = integration_tests(cihome)
+      tests_directory, = integration_tests(sdkhome)
       unless flavors.include?('default')
         tests_directory = tests_directory.reject do |test|
           /.*#{flavors}.*$/.match(test).nil?


### PR DESCRIPTION
This was probably the cleanest thing to do as our users/customers will never have a notion of any ci_home directory (as we removed it in our `extras` and `core` repos). Unfortunately that meant changing the template. 
If anyone was in the middle of porting a check to the SDK and your tests misteriously stop working after updating the gem, it's because you have to update your foo/ci/foo.rake files to not pass the `ci_home` argument when invoking the tests. Look at the changes to the template to see exactly the changes you should make to your rakefiles.
