### PR TITLE
[gem] putting reqs install into task in common - run it before lint

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -150,6 +150,8 @@ namespace :ci do
       section('INSTALL')
       use_venv = in_venv
       pip_command = use_venv ? 'venv/bin/pip' : 'pip'
+      sdk_dir = ENV['SDK_HOME'] || Dir.pwd
+
       sh %(#{'python -m ' if Gem.win_platform?}#{pip_command} install --upgrade pip setuptools)
       install_requirements('requirements.txt',
                            "--cache-dir #{ENV['PIP_CACHE']}",
@@ -160,6 +162,17 @@ namespace :ci do
       install_requirements('requirements-test.txt',
                            "--cache-dir #{ENV['PIP_CACHE']}",
                            "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+
+      reqs = Dir.glob(File.join(sdk_dir, '**/requirements.txt')).reject do |path|
+        !%r{#{sdk_dir}/embedded/.*$}.match(path).nil? || !%r{#{sdk_dir}\/venv\/.*$}.match(path).nil?
+      end
+
+      reqs.each do |req|
+        install_requirements(req,
+                             "--cache-dir #{ENV['PIP_CACHE']}",
+                             "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      end
+
       t.reenable
     end
 

--- a/lib/tasks/ci/default.rb
+++ b/lib/tasks/ci/default.rb
@@ -19,23 +19,11 @@ namespace :ci do
       end
     end
 
-    task install: ['ci:common:install'] do
-      sdk_dir = ENV['SDK_HOME'] || Dir.pwd
-      reqs = Dir.glob(File.join(sdk_dir, '**/requirements.txt')).reject do |path|
-        !%r{#{sdk_dir}/embedded/.*$}.match(path).nil? || !%r{#{sdk_dir}\/venv\/.*$}.match(path).nil?
-      end
-
-      use_venv = in_venv
-      reqs.each do |req|
-        install_requirements(req,
-                             "--cache-dir #{ENV['PIP_CACHE']}",
-                             "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
-      end
-    end
+    task install: ['ci:common:install']
 
     task before_script: ['ci:common:before_script']
 
-    task lint: ['rubocop'] do
+    task lint: ['ci:common:install', 'rubocop'] do
       check_env
       sh %(flake8 #{ENV['SDK_HOME']})
       sh %(find #{ENV['SDK_HOME']} -name '*.py' -not\


### PR DESCRIPTION
Just a small refactor, moving the `installation of the requirements.txt` files to its own task, and then making it a dependency for default - other relevant tasks probably already depended on `ci:common:install` and should be fine.
