### PR TITLE
Fixes the setup hooks rake task

### DIFF
--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -55,7 +55,7 @@ desc 'Setup git hooks'
 task 'setup_hooks' do
   check_env
   gem_home = Bundler.rubygems.find_name('datadog-sdk-testing').first.full_gem_path
-  sh "ln -sf #{gem_home}/lib/tasks/ci/hooks/pre-commit.py #{ENV['SDK_HOME']}}/.git/hooks/pre-commit"
+  sh "ln -sf #{gem_home}/lib/tasks/ci/hooks/pre-commit.py #{ENV['SDK_HOME']}/.git/hooks/pre-commit"
 end
 
 desc 'Pull latest agent code'


### PR DESCRIPTION
The setup hooks rake task has an extra `}` in the environment variable interpolation. This removes it.
