### PR TITLE
Fixes lint failures

### DIFF
--- a/lib/tasks/ci/default.rb
+++ b/lib/tasks/ci/default.rb
@@ -23,7 +23,7 @@ namespace :ci do
 
     task before_script: ['ci:common:before_script']
 
-    task lint: ['ci:common:install', 'rubocop'] do
+    task lint: ['ci:common:before_script', 'ci:common:install', 'rubocop'] do
       check_env
       sh %(flake8 #{ENV['SDK_HOME']})
       sh %(find #{ENV['SDK_HOME']} -name '*.py' -not\


### PR DESCRIPTION
The lint step fails on the install stage because because we don't have the volatile dir created, this adds before install from the common tasks to the lint task.
