### PR TITLE
adds copyright notice to skeleton

### DIFF
--- a/lib/config/check.py
+++ b/lib/config/check.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
 # stdlib
 
 # 3rd party

--- a/lib/config/test_skeleton.py
+++ b/lib/config/test_skeleton.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
 # stdlib
 from nose.plugins.attrib import attr
 


### PR DESCRIPTION
The skeleton should generate the copyright notice on top of each file it creates.

This Pull Request will add it to the top of the test file and the check file. 

Some files it cannot be added to, e.g. the manifest.json. We might also want to add it to the rake file.