### PR TITLE
The comma should have been a dot

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -138,7 +138,7 @@ end
 
 def generate_skeleton(integration)
   copy_skeleton('lib/config/ci/skeleton.rake', "ci/#{integration}.rake", integration)
-  copy_skeleton('lib/config/manifest.json', 'manifest,json', integration)
+  copy_skeleton('lib/config/manifest.json', 'manifest.json', integration)
   copy_skeleton('lib/config/check.py', 'check.py', integration)
   copy_skeleton('lib/config/test_skeleton.py', "test_#{integration}.py", integration)
   copy_skeleton('lib/config/metadata.csv', 'metadata.csv', integration)


### PR DESCRIPTION
This fixes a small typo, the generate task was generating `manifest,json` but it was a typo. It should have been `manifest.json`.