### PR TITLE
Wait.for will not work with docker

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,6 @@ Style/Documentation:
 # Configuration parameters: Methods.
 Style/SingleLineBlockParams:
   Enabled: false
+
+BlockLength:
+  Max: 90

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -174,7 +174,7 @@ class Wait
         s = TCPSocket.new('localhost', port)
         s.close
         return true
-      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError
         return false
       end
     end
@@ -187,7 +187,7 @@ class Wait
       begin
         r = HTTParty.get(url)
         return (200...300).cover? r.code
-      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError
         return false
       end
     end

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -39,10 +39,9 @@ def install_req(requirement, pip_options = nil, output = nil, use_venv = nil)
   pip_command = use_venv ? "#{ENV['SDK_HOME']}/venv/bin/pip" : 'pip'
   redirect_output = output ? "2>&1 >> #{output}" : ''
   pip_options = '' if pip_options.nil?
-  unless requirement.empty? || requirement.start_with?('#')
-    sh %(#{pip_command} install #{requirement} #{pip_options} #{redirect_output}\
-         || echo 'Unable to install #{requirement}' #{redirect_output})
-  end
+  return if requirement.empty? || requirement.start_with?('#')
+  sh %(#{pip_command} install #{requirement} #{pip_options} #{redirect_output}\
+       || echo 'Unable to install #{requirement}' #{redirect_output})
 end
 
 def install_requirements(req_file, pip_options = nil, output = nil, use_venv = nil)

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -39,7 +39,7 @@ def install_req(requirement, pip_options = nil, output = nil, use_venv = nil)
   pip_command = use_venv ? "#{ENV['SDK_HOME']}/venv/bin/pip" : 'pip'
   redirect_output = output ? "2>&1 >> #{output}" : ''
   pip_options = '' if pip_options.nil?
-  return if requirement.empty? || requirement.start_with?('#')
+  return true if requirement.empty? || requirement.start_with?('#')
   sh %(#{pip_command} install #{requirement} #{pip_options} #{redirect_output}\
        || echo 'Unable to install #{requirement}' #{redirect_output})
 end


### PR DESCRIPTION
Right now, when we use `Wait.for` with docker, it will fail on an `EOFile` error, because docker will be returning nothing from the process inside of it. This change rescues it, and returns the proper answer, instead of erroring out.