### PR TITLE
Reset Connection error should be rescued in wait as well

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -173,7 +173,7 @@ class Wait
         s = TCPSocket.new('localhost', port)
         s.close
         return true
-      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError, Errno::ECONNRESET
         return false
       end
     end
@@ -186,7 +186,7 @@ class Wait
       begin
         r = HTTParty.get(url)
         return (200...300).cover? r.code
-      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError, Errno::ECONNRESET
         return false
       end
     end


### PR DESCRIPTION
Wait also fails on connection reset, we should rescue it there, too.