### PR TITLE
[gem][docker] add helper to wait for logs expression hit or raise.

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -28,6 +28,25 @@ def sleep_for(secs)
   sleep(secs)
 end
 
+def wait_on_docker_logs(c_name, max_wait, *include_array)
+  count = 0
+  logs = `docker logs #{c_name} 2>&1`
+  puts "Waiting for #{c_name} to come up"
+
+  until count == max_wait or include_array.any? { |phrase| logs.include?(phrase) }
+    sleep(1)
+    logs = `docker logs #{c_name} 2>&1`
+    count += 1
+  end
+
+  if include_array.any? { |phrase| logs.include?(phrase) }
+      puts "#{c_name} is up!"
+  else
+    sh %(docker logs #{c_name} 2>&1)
+    raise
+  end
+end
+
 def section(name)
   timestamp = Time.now.utc.iso8601
   puts ''

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -33,14 +33,14 @@ def wait_on_docker_logs(c_name, max_wait, *include_array)
   logs = `docker logs #{c_name} 2>&1`
   puts "Waiting for #{c_name} to come up"
 
-  until count == max_wait or include_array.any? { |phrase| logs.include?(phrase) }
+  until count == max_wait || include_array.any? { |phrase| logs.include?(phrase) }
     sleep(1)
     logs = `docker logs #{c_name} 2>&1`
     count += 1
   end
 
   if include_array.any? { |phrase| logs.include?(phrase) }
-      puts "#{c_name} is up!"
+    puts "#{c_name} is up!"
   else
     sh %(docker logs #{c_name} 2>&1)
     raise


### PR DESCRIPTION
Including small helper by @gmmeyer to wait until we have a specific output in the docker logs. This is often more reliable than waiting for a port, it's not uncommon to have the socket open while the process is still coming up.

If we don't have a hit in `max_time` seconds, we will just raise.