### PR TITLE
remove auto execution

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -343,7 +343,5 @@ namespace :ci do
       end
       t.reenable
     end
-
-    task execute: [:before_install, :install, :before_script, :script]
   end
 end


### PR DESCRIPTION
Either the execution in the skeleton is redundant or the auto execution is redundant. It makes more sense that this is than the skeleton.