### PR TITLE
[sdk] Using explict python2 for compat on python3-default systems

### DIFF
--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -19,7 +19,7 @@ task 'setup_env' do
   check_env
   `mkdir -p #{ENV['SDK_HOME']}/venv`
   `wget -q -O #{ENV['SDK_HOME']}/venv/virtualenv.py https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py`
-  `python #{ENV['SDK_HOME']}/venv/virtualenv.py  --no-site-packages --no-pip --no-setuptools #{ENV['SDK_HOME']}/venv/`
+  `python2 #{ENV['SDK_HOME']}/venv/virtualenv.py  --no-site-packages --no-pip --no-setuptools #{ENV['SDK_HOME']}/venv/`
   `wget -q -O #{ENV['SDK_HOME']}/venv/ez_setup.py https://bootstrap.pypa.io/ez_setup.py`
   `#{ENV['SDK_HOME']}/venv/bin/python #{ENV['SDK_HOME']}/venv/ez_setup.py`
   `wget -q -O #{ENV['SDK_HOME']}/venv/get-pip.py https://bootstrap.pypa.io/get-pip.py`


### PR DESCRIPTION
Related to https://github.com/DataDog/integrations-extras/issues/20

Tested on my own system: Archlinux, RVM-installed `ruby 2.4.0p0` with `python2.7.13`.

It might be worth testing this on other systems since, if memory serves me right, not all distributions are providing the `python2` binary when installing python2.x (i.e. `/usr/bin/python` and `/usr/bin/python2.7` are installed but not `/usr/bin/python2`.)