### PR TITLE
[rubocop] Fix patterns of rubocoped files

### DIFF
--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -107,7 +107,7 @@ namespace :test do
 end
 
 RuboCop::RakeTask.new(:rubocop) do |t|
-  t.patterns = ['ci/**/*.rb', 'Gemfile', 'Rakefile']
+  t.patterns = ['./*/ci/*.rake', 'Gemfile', 'Rakefile']
 end
 
 desc 'Lint the code through pylint'


### PR DESCRIPTION
Update the pattern with the current structure of the integration SDK repos, so that it actually runs on all the rake files. Not super important but nice to have.

Warning: with the updated pattern, rubocop finds `>100` offenses on the `integrations-core` repo right now. I can work on fixing them if needed.

On a related note, the `.rubocop.yml` file of this repo is not shipped with the gem and not taken into account in the integration sdk repos. Unsure as to what we should do (if we want to do anything), I'd be fine with having separate rubocop configs for each repo.