### PR TITLE
Fix type miss match on generator

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -163,9 +163,8 @@ end
 
 def replace_guid(integration)
   guid = SecureRandom.uuid
-  f = File.open("#{ENV['SDK_HOME']}/#{integration}/manifest.json")
+  f = "#{ENV['SDK_HOME']}/#{integration}/manifest.json"
   sed(f, 's', 'guid_replaceme', guid.to_s, 'g')
-  file.close
 end
 
 def generate_skeleton(integration)


### PR DESCRIPTION
When I ran `rake generate:skeleton` sed command failed due to type mismatch.
This change fixes the issue.

## Error message

```
sed -i '' "s/guid_replaceme/346af33e-c6ab-4b1f-b7a9-0dbe9b08525d/g" #<File:0x007fc79c126108>
sed: -i may not be used with stdin
rake aborted!
Command failed with status (1): [sed -i '' "s/guid_replaceme/346af33e-c6ab-...]
```

## Full logs

```
% bundle exec rake 'generate:skeleton[test]'
generating skeleton files for test
mkdir -p /Users/kazuhiro/work/integrations-extras/test/ci
cp /Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/config/ci/skeleton.rake /Users/kazuhiro/work/integrations-extras/test/ci/test.rake
cp /Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/config/manifest.json /Users/kazuhiro/work/integrations-extras/test/manifest.json
cp /Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/config/check.py /Users/kazuhiro/work/integrations-extras/test/check.py
cp /Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/config/test_skeleton.py /Users/kazuhiro/work/integrations-extras/test/test_test.py
cp /Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/config/metadata.csv /Users/kazuhiro/work/integrations-extras/test/metadata.csv
cp /Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/config/requirements.txt /Users/kazuhiro/work/integrations-extras/test/requirements.txt
cp /Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/config/README.md /Users/kazuhiro/work/integrations-extras/test/README.md
cp /Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/config/conf.yaml.example /Users/kazuhiro/work/integrations-extras/test/conf.yaml.example
sed -i '' "s/skeleton/test/g" /Users/kazuhiro/work/integrations-extras/test/check.py
sed -i '' "s/Skeleton/Test/g" /Users/kazuhiro/work/integrations-extras/test/check.py
sed -i '' "s/skeleton/test/g" /Users/kazuhiro/work/integrations-extras/test/ci/test.rake
sed -i '' "s/Skeleton/Test/g" /Users/kazuhiro/work/integrations-extras/test/ci/test.rake
sed -i '' "s/skeleton/test/g" /Users/kazuhiro/work/integrations-extras/test/conf.yaml.example
sed -i '' "s/Skeleton/Test/g" /Users/kazuhiro/work/integrations-extras/test/conf.yaml.example
sed -i '' "s/skeleton/test/g" /Users/kazuhiro/work/integrations-extras/test/manifest.json
sed -i '' "s/Skeleton/Test/g" /Users/kazuhiro/work/integrations-extras/test/manifest.json
sed -i '' "s/skeleton/test/g" /Users/kazuhiro/work/integrations-extras/test/metadata.csv
sed -i '' "s/Skeleton/Test/g" /Users/kazuhiro/work/integrations-extras/test/metadata.csv
sed -i '' "s/skeleton/test/g" /Users/kazuhiro/work/integrations-extras/test/README.md
sed -i '' "s/Skeleton/Test/g" /Users/kazuhiro/work/integrations-extras/test/README.md
sed -i '' "s/skeleton/test/g" /Users/kazuhiro/work/integrations-extras/test/requirements.txt
sed -i '' "s/Skeleton/Test/g" /Users/kazuhiro/work/integrations-extras/test/requirements.txt
sed -i '' "s/skeleton/test/g" /Users/kazuhiro/work/integrations-extras/test/test_test.py
sed -i '' "s/Skeleton/Test/g" /Users/kazuhiro/work/integrations-extras/test/test_test.py
sed -i '' "s/guid_replaceme/346af33e-c6ab-4b1f-b7a9-0dbe9b08525d/g" #<File:0x007fc79c126108>
sed: -i may not be used with stdin
rake aborted!
Command failed with status (1): [sed -i '' "s/guid_replaceme/346af33e-c6ab-...]
/Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/tasks/ci/common.rb:23:in `sed'
/Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/tasks/ci/common.rb:167:in `replace_guid'
/Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/tasks/ci/common.rb:193:in `create_skeleton'
/Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/datadog-sdk-testing-0.4.7/lib/tasks/sdk.rake:125:in `block (2 levels) in <top (required)>'
/Users/kazuhiro/work/integrations-extras/vendor/bundle/ruby/2.3.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/Users/kazuhiro/.rbenv/versions/2.3.1/bin/bundle:23:in `load'
/Users/kazuhiro/.rbenv/versions/2.3.1/bin/bundle:23:in `<main>'
Tasks: TOP => generate:skeleton
(See full trace by running task with --trace)
```