### PR TITLE
[reqstool] Revamp of the requirements tool/hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ ENV['SDK_HOME'] = File.dirname(__FILE__)
 spec = Gem::Specification.find_by_name 'datadog-sdk-testing'
 load "#{spec.gem_dir}/lib/tasks/sdk.rake"
 ```
+
+if you wish to enable the remote facilities for the requirement conflict checking [tool](https://github.com/DataDog/datadog-sdk-testing/blob/master/lib/tasks/ci/hooks/pre-commit.py) you will have to install [github3.py](https://github.com/sigmavirus24/github3.p://github.com/sigmavirus24/github3.py) (pre-release):
+```
+pip install --pre github3.py
+```
+By default this tool is designed to be used as a pre-commit hook and runs only on local repos. Due to the duration of the validation runs it's not recommended to enable remote repos when using as a pre-commit hook. We perform requirement validation in our continuous integration environment, so it's definitely not mandatory.

--- a/lib/tasks/ci/hooks/pre-commit.py
+++ b/lib/tasks/ci/hooks/pre-commit.py
@@ -121,6 +121,7 @@ class RequirementsAnalyzer(object):
         return reqs
 
     def process_requirements(self, sources):
+        err = 0
         reqs = {}
 
         for source, requirements in sources.iteritems():
@@ -149,12 +150,13 @@ class RequirementsAnalyzer(object):
                                     src=reqs[req][1],
                                     repo=reqs[req][2]
                                 )
+                            err = ERR
                             break
                         elif req not in reqs:
                             reqs[req] = (specifier, integration, source)
                             break
 
-        return reqs
+        return err, reqs
 
 
 def main(args):
@@ -173,19 +175,18 @@ def main(args):
     analyzer = RequirementsAnalyzer(
         remote=remote, local=local, patterns=['requirements*.txt'])
 
-    analyzer.process_requirements(analyzer.get_all_requirements())
-#   reqs = analyzer.process_requirements(analyzer.get_all_requirements())
-#   print "No requirement version conflicts found. Looking good... ;)"
-#   for requirement, spec in reqs.iteritems():
-#       print "{req}{spec} first found in {fname} @ {source}".format(
-#           req=requirement,
-#           spec=spec[0],
-#           fname=spec[1],
-#           source=spec[2]
-#       )
+    err, reqs = analyzer.process_requirements(analyzer.get_all_requirements())
+    if not err:
+        print "No requirement version conflicts found. Looking good... ;)"
+        for requirement, spec in reqs.iteritems():
+            print "{req}{spec} first found in {fname} @ {source}".format(
+                req=requirement,
+                spec=spec[0],
+                fname=spec[1],
+                source=spec[2]
+            )
+
+    sys.exit(err)
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-
-
-sys.exit(0)

--- a/lib/tasks/ci/hooks/pre-commit.py
+++ b/lib/tasks/ci/hooks/pre-commit.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
-import github3
-
 import fnmatch
 import os
 import sys
+
+try:
+    import github3
+except ImportError:
+    github3 = None
 
 
 ERR = 1
@@ -35,16 +38,17 @@ class RequirementsAnalyzer(object):
         self.local_sources = local
         self.req_patterns = patterns
 
-        if os.environ.get(ENV_TOKEN):
-            self.api = github3.login(
-                token=os.environ.get(ENV_TOKEN)
-            )
-        elif os.environ.get(ENV_USER) and os.environ.get(ENV_PASS):
-            self.api = github3.login(
-                os.environ.get(ENV_USER),
-                os.environ(ENV_PASS),
-                two_factor_callback=two_fa
-            )
+        if github3:
+            if os.environ.get(ENV_TOKEN):
+                self.api = github3.login(
+                    token=os.environ.get(ENV_TOKEN)
+                )
+            elif os.environ.get(ENV_USER) and os.environ.get(ENV_PASS):
+                self.api = github3.login(
+                    os.environ.get(ENV_USER),
+                    os.environ(ENV_PASS),
+                    two_factor_callback=two_fa
+                )
 
     def get_repo_requirements(self, repo):
         reqs = {}


### PR DESCRIPTION
Revamped version allows comparison of versions across repositories, local and remote. It relies on `github3.py` to access github repos. It supports:
- regular authentication
- 2FA 
- Token based authentication. 

If no authentication method is provided, it will just ignore remote repositories. Similarly, to avoid being overly invasive, if the `github3.py` library is missing, it will also ignore remote repositories. 

It supports both command-line arguments and environment variables as means to provide the arguments.