### PR TITLE
sed + git change propositions

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -19,11 +19,7 @@ end
 def sed(source, op, a, b, mods)
   cmd = "#{op}/#{a}"
   cmd = "#{cmd}/#{b}" unless b.nil? || b.empty?
-  if RUBY_PLATFORM.include? 'darwin'
-    sh "sed -i '' \"#{cmd}/#{mods}\" #{source}"
-  else
-    sh "sed -i \"#{cmd}/#{mods}\" #{source}"
-  end
+  sh "sed -i '' \"#{cmd}/#{mods}\" #{source} || sed -i \"#{cmd}/#{mods}\" #{source}"
 end
 
 def sleep_for(secs)

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -192,8 +192,6 @@ def create_skeleton(integration)
 
   replace_guid(integration.to_s)
 
-  sh "git add #{ENV['SDK_HOME']}/#{integration}/"
-
   add_travis_flavor(integration)
   add_circleci_flavor(integration)
 end

--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -70,7 +70,7 @@ task 'wipe', :option do |_, args|
     sed("#{ENV['SDK_HOME']}/.travis.yml", '', "=#{flavor}\\ ", '', 'd')
     sed("#{ENV['SDK_HOME']}/.travis.yml", '', "=#{flavor}$", '', 'd')
     sed("#{ENV['SDK_HOME']}/circle.yml", '', "\\[#{flavor}\\]", '', 'd')
-    `git rm -r #{flavor}`
+    puts "Please run 'git rm -r #{flavor}' to complete the wipe."
   when 'N'
     puts 'aborting the task...'
   end


### PR DESCRIPTION
## 	Do not call git for the user

IMO the user is responsible for Git, and we shouldn't try to run git
commands (even though they are completely safe).
Futhermore the `git add` one is not so useful, since the user still has
to modify the check before it's usable.
I replaced the `git rm` by a suggestion to run git rm.

## 	Handle GNU sed on mac
Suggested by Greg, just do an or, the first one will fail if sed is the
GNU one.