### PR TITLE
Potential improvements for future dev

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Style/SingleLineBlockParams:
   Enabled: false
 
 BlockLength:
-  Max: 90
+  Max: 102
 
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or

--- a/datadog-sdk-testing.gemspec
+++ b/datadog-sdk-testing.gemspec
@@ -6,23 +6,8 @@ Gem::Specification.new do |s|
   s.authors       = ['Jaime Fullaondo']
   s.email         = 'jaime.fullaondo@datadoghq.com'
   s.require_paths = ['lib/tasks/']
-  s.files         = ['lib/tasks/sdk.rake',
-                     'lib/tasks/ci/default.rb',
-                     'lib/tasks/ci/common.rb',
-                     'lib/tasks/ci/hooks/pre-commit.py',
-                     'lib/config/check.py',
-                     'lib/config/ci/skeleton.rake',
-                     'lib/config/conf.yaml.example',
-                     'lib/config/manifest.json',
-                     'lib/config/datadog.conf',
-                     'lib/config/metadata.csv',
-                     'lib/config/README.md',
-                     'lib/config/CHANGELOG.md',
-                     'lib/config/requirements.txt',
-                     'lib/config/test_skeleton.py',
-                     'README.md',
-                     'LICENSE']
-  s.homepage      = 'http://rubygems.org/gems/datadog-sdk-testing'
+  s.files         = Dir['lib/**/*'] + ['README.md', 'LICENSE']
+  s.homepage      = 'https://rubygems.org/gems/datadog-sdk-testing'
   s.license       = 'MIT'
   s.add_runtime_dependency 'colorize', '~> 0.8'
   s.add_runtime_dependency 'httparty', '~> 0.14'

--- a/lib/config/ci/skeleton.rake
+++ b/lib/config/ci/skeleton.rake
@@ -40,7 +40,7 @@ namespace :ci do
     task :execute do
       exception = nil
       begin
-        %w(before_install install before_script).each do |u|
+        %w[before_install install before_script].each do |u|
           Rake::Task["#{flavor.scope.path}:#{u}"].invoke
         end
         if !ENV['SKIP_TEST']

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -1,60 +1,19 @@
 require 'colorize'
-require 'httparty'
-require 'socket'
 require 'time'
-require 'timeout'
-require 'securerandom'
+
+require_relative 'utils/ci'
+require_relative 'utils/skeleton'
+require_relative 'utils/skip'
+require_relative 'utils/wait'
 
 # Colors don't work on Appveyor
 String.disable_colorization = true if Gem.win_platform?
-
-def check_env
-  abort 'SDK_HOME env variable must be defined in your Rakefile to used this gem.' unless ENV['SDK_HOME']
-end
-
-def travis_circle_env
-  abort 'You are not in a Travis/Circle CI environment, this task wont apply.' if !ENV['TRAVIS'] && !ENV['CIRCLECI']
-end
-
-def sed(source, op, a, b, mods)
-  cmd = "#{op}/#{a}"
-  cmd = "#{cmd}/#{b}" unless b.nil? || b.empty?
-  sh "sed -i '' \"#{cmd}/#{mods}\" #{source} || sed -i \"#{cmd}/#{mods}\" #{source}"
-end
-
-def sleep_for(secs)
-  puts "Sleeping for #{secs}s".blue
-  sleep(secs)
-end
-
-def wait_on_docker_logs(c_name, max_wait, *include_array)
-  count = 0
-  logs = `docker logs #{c_name} 2>&1`
-  puts "Waiting for #{c_name} to come up"
-
-  until count == max_wait || include_array.any? { |phrase| logs.include?(phrase) }
-    sleep(1)
-    logs = `docker logs #{c_name} 2>&1`
-    count += 1
-  end
-
-  if include_array.any? { |phrase| logs.include?(phrase) }
-    puts "#{c_name} is up!"
-  else
-    sh %(docker logs #{c_name} 2>&1)
-    raise
-  end
-end
 
 def section(name)
   timestamp = Time.now.utc.iso8601
   puts ''
   puts "[#{timestamp}] >>>>>>>>>>>>>> #{name} STAGE".black.on_white
   puts ''
-end
-
-def in_venv
-  ENV['RUN_VENV'] && ENV['RUN_VENV'] == 'true' ? true : false
 end
 
 def install_requirements(req_file, pip_options = nil, output = nil, use_venv = nil)
@@ -64,214 +23,12 @@ def install_requirements(req_file, pip_options = nil, output = nil, use_venv = n
   sh "#{pip_command} install -r #{req_file} #{pip_options} #{redirect_output}"
 end
 
-def test_files(sdk_dir)
-  Dir.glob(File.join(sdk_dir, '**/test_*.py')).reject do |path|
-    !%r{#{sdk_dir}/embedded/.*$}.match(path).nil? || !%r{#{sdk_dir}\/venv\/.*$}.match(path).nil?
-  end
-end
-
-def integration_tests(root_dir)
-  sdk_dir = ENV['SDK_HOME'] || root_dir
-  integrations = []
-  untested = []
-  testable = []
-  test_files(sdk_dir).each do |check|
-    integration_name = /test_((\w|_)+).py$/.match(check)[1]
-    integrations.push(integration_name)
-    if Dir.exist?(File.join(sdk_dir, integration_name))
-      testable.push(check)
-    else
-      untested.push(check)
-    end
-  end
-  [testable, untested]
-end
-
-def move_file(src, dst)
-  File.delete(dst)
-  File.rename(src, dst)
-end
-
-def check_travis_flavor(flavor, version = nil)
-  version = 'latest' if version.nil?
-  File.foreach("#{ENV['SDK_HOME']}/.travis.yml") do |line|
-    return false if line =~ /- TRAVIS_FLAVOR=#{flavor} FLAVOR_VERSION=#{version}/
-  end
-  true
-end
-
-def add_travis_flavor(flavor, version = nil)
-  new_file = "#{ENV['SDK_HOME']}/.travis.yml.new"
-  version = 'latest' if version.nil?
-  added = false
-  File.open(new_file, 'w') do |fo|
-    File.foreach("#{ENV['SDK_HOME']}/.travis.yml") do |line|
-      if !added && line =~ /# END OF TRAVIS MATRIX|- TRAVIS_FLAVOR=#{flavor}/
-        fo.puts "    - TRAVIS_FLAVOR=#{flavor} FLAVOR_VERSION=#{version}"
-        added = true
-      end
-      fo.puts line
-    end
-  end
-  move_file(new_file, "#{ENV['SDK_HOME']}/.travis.yml")
-end
-
-def add_circleci_flavor(flavor)
-  new_file = "#{ENV['SDK_HOME']}/circle.yml.new"
-  File.open(new_file, 'w') do |fo|
-    File.foreach("#{ENV['SDK_HOME']}/circle.yml") do |line|
-      fo.puts "        - rake ci:run[#{flavor}]" if line =~ /bundle\ exec\ rake\ requirements/
-      fo.puts line
-    end
-  end
-  move_file(new_file, "#{ENV['SDK_HOME']}/circle.yml")
-end
-
-def copy_skeleton(source, dst, integration)
-  gem_home = Bundler.rubygems.find_name('datadog-sdk-testing').first.full_gem_path
-  sh "cp #{gem_home}/#{source} #{ENV['SDK_HOME']}/#{integration}/#{dst}"
-end
-
-def create_integration_path(integration)
-  sh "mkdir -p #{ENV['SDK_HOME']}/#{integration}/ci"
-end
-
-def rename_skeleton(integration)
-  capitalized = integration.capitalize
-  Dir.glob("#{ENV['SDK_HOME']}/#{integration}/**/*") do |f|
-    if File.file?(f)
-      sed(f, 's', 'skeleton', integration.to_s, 'g')
-      sed(f, 's', 'Skeleton', capitalized.to_s, 'g')
-    end
-  end
-end
-
-def replace_guid(integration)
-  guid = SecureRandom.uuid
-  f = "#{ENV['SDK_HOME']}/#{integration}/manifest.json"
-  sed(f, 's', 'guid_replaceme', guid.to_s, 'g')
-end
-
-def generate_skeleton(integration)
-  copy_skeleton('lib/config/ci/skeleton.rake', "ci/#{integration}.rake", integration)
-  copy_skeleton('lib/config/manifest.json', 'manifest.json', integration)
-  copy_skeleton('lib/config/check.py', 'check.py', integration)
-  copy_skeleton('lib/config/test_skeleton.py', "test_#{integration}.py", integration)
-  copy_skeleton('lib/config/metadata.csv', 'metadata.csv', integration)
-  copy_skeleton('lib/config/requirements.txt', 'requirements.txt', integration)
-  copy_skeleton('lib/config/README.md', 'README.md', integration)
-  copy_skeleton('lib/config/CHANGELOG.md', 'CHANGELOG.md', integration)
-  copy_skeleton('lib/config/conf.yaml.example', 'conf.yaml.example', integration)
-end
-
-def create_skeleton(integration)
-  if File.directory?("#{ENV['SDK_HOME']}/#{integration}")
-    puts "directory already exists for #{integration} - bailing out."
-    return
-  end
-
-  puts "generating skeleton files for #{integration}"
-  create_integration_path(integration.to_s)
-  generate_skeleton(integration.to_s)
-  rename_skeleton(integration.to_s)
-
-  replace_guid(integration.to_s)
-
-  add_travis_flavor(integration)
-  add_circleci_flavor(integration)
-end
-
-# helper class to wait for TCP/HTTP services to boot
-class Wait
-  DEFAULT_TIMEOUT = 10
-
-  def self.check_port(port)
-    Timeout.timeout(0.5) do
-      begin
-        s = TCPSocket.new('localhost', port)
-        s.close
-        return true
-      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError, Errno::ECONNRESET
-        return false
-      end
-    end
-  rescue Timeout::Error
-    return false
-  end
-
-  def self.check_url(url)
-    Timeout.timeout(0.5) do
-      begin
-        r = HTTParty.get(url)
-        return (200...300).cover? r.code
-      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError, Errno::ECONNRESET
-        return false
-      end
-    end
-  rescue Timeout::Error
-    return false
-  end
-
-  def self.check_file(file_path)
-    File.exist?(file_path)
-  end
-
-  def self.check(smth)
-    if smth.is_a? Integer
-      check_port smth
-    elsif smth.include? 'http'
-      check_url smth
-    else
-      check_file smth
-    end
-  end
-
-  def self.for(smth, max_timeout = DEFAULT_TIMEOUT)
-    start_time = Time.now
-    status = false
-    n = 1
-    puts "Trying #{smth}"
-    loop do
-      puts n.to_s
-      status = check(smth)
-      break if status || Time.now > start_time + max_timeout
-      n += 1
-      sleep 0.25
-    end
-    raise "Still not up after #{max_timeout}s" unless status
-    puts 'Found!'
-    status
-  end
-end
-
-def travis_pr?
-  !ENV['TRAVIS'].nil? && ENV['TRAVIS_EVENT_TYPE'] == 'pull_request'
-end
-
-def can_skip?
-  return false, [] unless travis_pr?
-
-  modified_checks = []
-  puts "Comparing #{ENV['TRAVIS_PULL_REQUEST_SHA']} with #{ENV['TRAVIS_BRANCH']}"
-  git_output = `git diff --name-only #{ENV['TRAVIS_BRANCH']}...#{ENV['TRAVIS_PULL_REQUEST_SHA']}`
-  puts "Git diff: \n#{git_output}"
-  git_output.each_line do |filename|
-    filename.strip!
-    puts filename
-    return false, [] if filename.split('/').length < 2
-
-    check_name = filename.split('/')[0]
-    modified_checks << check_name unless modified_checks.include? check_name
-  end
-  [true, modified_checks]
-end
-
-def run_rake_task(task, flavor, common_task=nil)
+def run_rake_task(task, flavor, common_task = nil)
   task_name = "ci:#{flavor}:#{task}"
   if Rake::Task.task_defined?(task_name)
     Rake::Task[task_name].invoke
   else
-    task = if common_task.nil? then task else common_task end
+    task = common_task.nil? ? task : common_task
     Rake::Task["ci:common:#{task}"].invoke(flavor)
   end
 end
@@ -326,7 +83,7 @@ namespace :ci do
       t.reenable
     end
 
-    task :test, [:flavor] => :script do |t, attr|
+    task :test, [:flavor] => :script do |_t, attr|
       flavor = attr[:flavor]
       Rake::Task['ci:common:run_tests'].invoke([flavor])
     end
@@ -341,7 +98,7 @@ namespace :ci do
       t.reenable
     end
 
-    task :execute, [:flavor] do |t, attr|
+    task :execute, [:flavor] do |_t, attr|
       exception = nil
       flavor = attr[:flavor]
       begin

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -102,7 +102,7 @@ namespace :ci do
       exception = nil
       flavor = attr[:flavor]
       begin
-        %w(before_install install before_script).each do |task|
+        %w[before_install install before_script].each do |task|
           run_rake_task(task, flavor)
         end
         if ENV['SKIP_TEST']

--- a/lib/tasks/ci/default.rb
+++ b/lib/tasks/ci/default.rb
@@ -8,7 +8,6 @@ namespace :ci do
     task before_install: ['ci:common:before_install']
 
     task :coverage do
-      check_env
       testable, untested = integration_tests(File.dirname(__FILE__))
       total_checks = (untested + testable).length
       unless untested.empty?
@@ -27,7 +26,6 @@ namespace :ci do
       if ENV['SKIP_LINT']
         puts 'Skipping lint'.yellow
       else
-        check_env
         sh %(flake8 #{ENV['SDK_HOME']})
         if RUBY_PLATFORM.include? 'darwin'
           sh %(find #{ENV['SDK_HOME']} -name '*.py' -not\
@@ -42,13 +40,11 @@ namespace :ci do
     end
 
     task :requirements do
-      check_env
       gem_home = Bundler.rubygems.find_name('datadog-sdk-testing').first.full_gem_path
       sh "#{gem_home}/lib/tasks/ci/hooks/pre-commit.py"
     end
 
     task script: ['ci:common:script', :coverage, :lint] do
-      check_env
       Rake::Task['ci:common:run_tests'].invoke(['default'])
     end
 

--- a/lib/tasks/ci/default.rb
+++ b/lib/tasks/ci/default.rb
@@ -53,8 +53,8 @@ namespace :ci do
     task :execute do
       exception = nil
       begin
-        %w(before_install install before_script
-           script).each do |t|
+        %w[before_install install before_script
+           script].each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end
       rescue => e

--- a/lib/tasks/ci/utils/ci.rb
+++ b/lib/tasks/ci/utils/ci.rb
@@ -1,0 +1,58 @@
+def sleep_for(secs)
+  puts "Sleeping for #{secs}s".blue
+  sleep(secs)
+end
+
+def wait_on_docker_logs(c_name, max_wait, *include_array)
+  count = 0
+  logs = `docker logs #{c_name} 2>&1`
+  puts "Waiting for #{c_name} to come up"
+
+  until count == max_wait || include_array.any? { |phrase| logs.include?(phrase) }
+    sleep(1)
+    logs = `docker logs #{c_name} 2>&1`
+    count += 1
+  end
+
+  if include_array.any? { |phrase| logs.include?(phrase) }
+    puts "#{c_name} is up!"
+  else
+    sh %(docker logs #{c_name} 2>&1)
+    raise
+  end
+end
+
+def in_venv
+  ENV['RUN_VENV'] && ENV['RUN_VENV'] == 'true' ? true : false
+end
+
+def test_files(sdk_dir)
+  Dir.glob(File.join(sdk_dir, '**/test_*.py')).reject do |path|
+    !%r{#{sdk_dir}/embedded/.*$}.match(path).nil? || !%r{#{sdk_dir}\/venv\/.*$}.match(path).nil?
+  end
+end
+
+def integration_tests(root_dir)
+  sdk_dir = ENV['SDK_HOME'] || root_dir
+  integrations = []
+  untested = []
+  testable = []
+  test_files(sdk_dir).each do |check|
+    integration_name = /test_((\w|_)+).py$/.match(check)[1]
+    integrations.push(integration_name)
+    if Dir.exist?(File.join(sdk_dir, integration_name))
+      testable.push(check)
+    else
+      untested.push(check)
+    end
+  end
+  [testable, untested]
+end
+
+def check_travis_flavor(flavor, version = nil)
+  version = 'latest' if version.nil?
+  File.foreach("#{ENV['SDK_HOME']}/.travis.yml") do |line|
+    return false if line =~ /- TRAVIS_FLAVOR=#{flavor} FLAVOR_VERSION=#{version}/
+  end
+  true
+end

--- a/lib/tasks/ci/utils/skeleton.rb
+++ b/lib/tasks/ci/utils/skeleton.rb
@@ -1,6 +1,5 @@
 require 'securerandom'
 
-
 def sed(source, op, a, b, mods)
   cmd = "#{op}/#{a}"
   cmd = "#{cmd}/#{b}" unless b.nil? || b.empty?

--- a/lib/tasks/ci/utils/skeleton.rb
+++ b/lib/tasks/ci/utils/skeleton.rb
@@ -1,0 +1,94 @@
+require 'securerandom'
+
+
+def sed(source, op, a, b, mods)
+  cmd = "#{op}/#{a}"
+  cmd = "#{cmd}/#{b}" unless b.nil? || b.empty?
+  sh "sed -i '' \"#{cmd}/#{mods}\" #{source} 2> /dev/null || sed -i \"#{cmd}/#{mods}\" #{source}"
+end
+
+def copy_skeleton(source, dst, integration)
+  gem_home = Bundler.rubygems.find_name('datadog-sdk-testing').first.full_gem_path
+  sh "cp #{gem_home}/#{source} #{ENV['SDK_HOME']}/#{integration}/#{dst}"
+end
+
+def create_integration_path(integration)
+  sh "mkdir -p #{ENV['SDK_HOME']}/#{integration}/ci"
+end
+
+def rename_skeleton(integration)
+  capitalized = integration.capitalize
+  Dir.glob("#{ENV['SDK_HOME']}/#{integration}/**/*") do |f|
+    if File.file?(f)
+      sed(f, 's', 'skeleton', integration.to_s, 'g')
+      sed(f, 's', 'Skeleton', capitalized.to_s, 'g')
+    end
+  end
+end
+
+def replace_guid(integration)
+  guid = SecureRandom.uuid
+  f = "#{ENV['SDK_HOME']}/#{integration}/manifest.json"
+  sed(f, 's', 'guid_replaceme', guid.to_s, 'g')
+end
+
+def move_file(src, dst)
+  File.delete(dst)
+  File.rename(src, dst)
+end
+
+def add_travis_flavor(flavor, version = nil)
+  new_file = "#{ENV['SDK_HOME']}/.travis.yml.new"
+  version = 'latest' if version.nil?
+  added = false
+  File.open(new_file, 'w') do |fo|
+    File.foreach("#{ENV['SDK_HOME']}/.travis.yml") do |line|
+      if !added && line =~ /# END OF TRAVIS MATRIX|- TRAVIS_FLAVOR=#{flavor}/
+        fo.puts "    - TRAVIS_FLAVOR=#{flavor} FLAVOR_VERSION=#{version}"
+        added = true
+      end
+      fo.puts line
+    end
+  end
+  move_file(new_file, "#{ENV['SDK_HOME']}/.travis.yml")
+end
+
+def add_circleci_flavor(flavor)
+  new_file = "#{ENV['SDK_HOME']}/circle.yml.new"
+  File.open(new_file, 'w') do |fo|
+    File.foreach("#{ENV['SDK_HOME']}/circle.yml") do |line|
+      fo.puts "        - rake ci:run[#{flavor}]" if line =~ /bundle\ exec\ rake\ requirements/
+      fo.puts line
+    end
+  end
+  move_file(new_file, "#{ENV['SDK_HOME']}/circle.yml")
+end
+
+def generate_skeleton(integration)
+  copy_skeleton('lib/config/ci/skeleton.rake', "ci/#{integration}.rake", integration)
+  copy_skeleton('lib/config/manifest.json', 'manifest.json', integration)
+  copy_skeleton('lib/config/check.py', 'check.py', integration)
+  copy_skeleton('lib/config/test_skeleton.py', "test_#{integration}.py", integration)
+  copy_skeleton('lib/config/metadata.csv', 'metadata.csv', integration)
+  copy_skeleton('lib/config/requirements.txt', 'requirements.txt', integration)
+  copy_skeleton('lib/config/README.md', 'README.md', integration)
+  copy_skeleton('lib/config/CHANGELOG.md', 'CHANGELOG.md', integration)
+  copy_skeleton('lib/config/conf.yaml.example', 'conf.yaml.example', integration)
+end
+
+def create_skeleton(integration)
+  if File.directory?("#{ENV['SDK_HOME']}/#{integration}")
+    puts "directory already exists for #{integration} - bailing out."
+    return
+  end
+
+  puts "generating skeleton files for #{integration}"
+  create_integration_path(integration.to_s)
+  generate_skeleton(integration.to_s)
+  rename_skeleton(integration.to_s)
+
+  replace_guid(integration.to_s)
+
+  add_travis_flavor(integration)
+  add_circleci_flavor(integration)
+end

--- a/lib/tasks/ci/utils/skip.rb
+++ b/lib/tasks/ci/utils/skip.rb
@@ -1,0 +1,21 @@
+def travis_pr?
+  !ENV['TRAVIS'].nil? && ENV['TRAVIS_EVENT_TYPE'] == 'pull_request'
+end
+
+def can_skip?
+  return false, [] unless travis_pr?
+
+  modified_checks = []
+  puts "Comparing #{ENV['TRAVIS_PULL_REQUEST_SHA']} with #{ENV['TRAVIS_BRANCH']}"
+  git_output = `git diff --name-only #{ENV['TRAVIS_BRANCH']}...#{ENV['TRAVIS_PULL_REQUEST_SHA']}`
+  puts "Git diff: \n#{git_output}"
+  git_output.each_line do |filename|
+    filename.strip!
+    puts filename
+    return false, [] if filename.split('/').length < 2
+
+    check_name = filename.split('/')[0]
+    modified_checks << check_name unless modified_checks.include? check_name
+  end
+  [true, modified_checks]
+end

--- a/lib/tasks/ci/utils/wait.rb
+++ b/lib/tasks/ci/utils/wait.rb
@@ -1,0 +1,68 @@
+require 'httparty'
+require 'socket'
+require 'time'
+require 'timeout'
+
+
+# helper class to wait for TCP/HTTP services to boot
+class Wait
+  DEFAULT_TIMEOUT = 10
+
+  def self.check_port(port)
+    Timeout.timeout(0.5) do
+      begin
+        s = TCPSocket.new('localhost', port)
+        s.close
+        return true
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError, Errno::ECONNRESET
+        return false
+      end
+    end
+  rescue Timeout::Error
+    return false
+  end
+
+  def self.check_url(url)
+    Timeout.timeout(0.5) do
+      begin
+        r = HTTParty.get(url)
+        return (200...300).cover? r.code
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError, Errno::ECONNRESET
+        return false
+      end
+    end
+  rescue Timeout::Error
+    return false
+  end
+
+  def self.check_file(file_path)
+    File.exist?(file_path)
+  end
+
+  def self.check(smth)
+    if smth.is_a? Integer
+      check_port smth
+    elsif smth.include? 'http'
+      check_url smth
+    else
+      check_file smth
+    end
+  end
+
+  def self.for(smth, max_timeout = DEFAULT_TIMEOUT)
+    start_time = Time.now
+    status = false
+    n = 1
+    puts "Trying #{smth}"
+    loop do
+      puts n.to_s
+      status = check(smth)
+      break if status || Time.now > start_time + max_timeout
+      n += 1
+      sleep 0.25
+    end
+    raise "Still not up after #{max_timeout}s" unless status
+    puts 'Found!'
+    status
+  end
+end

--- a/lib/tasks/ci/utils/wait.rb
+++ b/lib/tasks/ci/utils/wait.rb
@@ -3,7 +3,6 @@ require 'socket'
 require 'time'
 require 'timeout'
 
-
 # helper class to wait for TCP/HTTP services to boot
 class Wait
   DEFAULT_TIMEOUT = 10

--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -119,7 +119,6 @@ namespace :generate do
 
   desc 'Add a new integration flavor to Travis - option may be option or option,version'
   task :travis_flavor, [:option] do |_, args|
-
     integration = args[:option]
     flavor = 'latest'
     flavor = args.extras[0] if args.extras.count == 1
@@ -138,7 +137,7 @@ namespace :ci do
     puts 'Assuming you are running these tests locally' unless ENV['TRAVIS']
     flavor = args[:flavor] || ENV['TRAVIS_FLAVOR'] || 'default'
     can_skip, checks = can_skip?
-    can_skip &&= !%w(default).include?(flavor)
+    can_skip &&= !%w[default].include?(flavor)
 
     flavors = flavor.split(',')
     flavors.each do |f|

--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -17,7 +17,6 @@ CLOBBER.include '**/*.pyc'
 
 desc 'Setup a development environment for the SDK'
 task 'setup_env' do
-  check_env
   `mkdir -p #{ENV['SDK_HOME']}/venv`
   `wget -q -O #{ENV['SDK_HOME']}/venv/virtualenv.py https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py`
   `python #{ENV['SDK_HOME']}/venv/virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools #{ENV['SDK_HOME']}/venv/`
@@ -41,7 +40,6 @@ end
 
 desc 'Clean development environment for the SDK (remove!)'
 task 'clean_env' do
-  check_env
   print 'Are you sure you want to delete the SDK environment (y/n)? '
   input = STDIN.gets.chomp
   case input.upcase
@@ -58,7 +56,6 @@ desc 'Wipe integration'
 task 'wipe', :option do |_, args|
   flavor = args[:option] || false
   abort 'please specify an integration to remove' unless flavor
-  check_env
   print "Are you sure you want to remove the #{flavor} integration (y/n)? "
   input = STDIN.gets.chomp
   case input.upcase
@@ -78,29 +75,24 @@ end
 
 desc 'Setup git hooks'
 task 'setup_hooks' do
-  check_env
   gem_home = Bundler.rubygems.find_name('datadog-sdk-testing').first.full_gem_path
   sh "ln -sf #{gem_home}/lib/tasks/ci/hooks/pre-commit.py #{ENV['SDK_HOME']}/.git/hooks/pre-commit"
 end
 
 desc 'Prepare Travis/Circle CI'
 task 'prep_travis_ci' do
-  check_env
-  travis_circle_env
   gem_home = Bundler.rubygems.find_name('datadog-sdk-testing').first.full_gem_path
   sh "ln -sf #{gem_home}/lib/config/datadog.conf ~/dd-agent/datadog.conf"
 end
 
 desc 'Pull latest agent code'
 task 'pull_latest_agent' do
-  check_env
   `cd #{ENV['SDK_HOME']}/embedded/dd-agent && git fetch -p && git pull --depth 1 && cd -`
 end
 
 namespace :test do
   desc 'cProfile tests, then run pstats'
   task 'profile:pstats' => ['test:profile'] do
-    check_env
     sh 'python -m pstats stats.dat'
   end
 
@@ -117,19 +109,16 @@ task 'lint' => ['ci:default:lint'] do
 end
 
 desc 'Find requirements conflicts'
-task 'requirements' => ['ci:default:requirements'] do
-end
+task 'requirements' => ['ci:default:requirements']
 
 namespace :generate do
   desc 'Setup a development environment for the SDK'
   task :skeleton, :option do |_, args|
-    check_env
     create_skeleton(args[:option])
   end
 
   desc 'Add a new integration flavor to Travis - option may be option or option,version'
   task :travis_flavor, [:option] do |_, args|
-    check_env
 
     integration = args[:option]
     flavor = 'latest'
@@ -146,7 +135,6 @@ end
 namespace :ci do
   desc 'Run integration tests'
   task :run, [:flavor] do |_, args|
-    check_env
     puts 'Assuming you are running these tests locally' unless ENV['TRAVIS']
     flavor = args[:flavor] || ENV['TRAVIS_FLAVOR'] || 'default'
     can_skip, checks = can_skip?

--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -158,7 +158,12 @@ namespace :ci do
         puts "skipping #{flavor} tests, not affected by the change".yellow
         next
       end
-      Rake::Task["ci:#{f}:execute"].invoke
+      task_name = "ci:#{f}:execute"
+      if Rake::Task.task_defined?(task_name)
+        Rake::Task[task_name].invoke
+      else
+        Rake::Task['ci:common:execute'].invoke(f)
+      end
     end
   end
 end


### PR DESCRIPTION
## 	[ci] call default task by default
First and maybe most important one, call default task by default. This means that you don't have to redefine all the subtasks in the *.rake, only the one you actually want to modify. Otherwise, only the default task will be executed. This will allow us to get rid of the multiple copies of `ci:execute` in all the *.rake (and many useless task definitions).

## 	[ci] smaller files, hopefully easier to understand
Attempt at dividing the big common.rb into smaller files (more or less by feature) so that it's (hopefully) easier to read.

##	[ci] remove requirements to run the command
I removed without paying attention a few functions that are actually validating that the user is launching the command is in a integration SDK env. Since most of them are used in the CI, I thought that we could get rid of them. Another way to implement them would be to have all these tasks inherit from another one that would only do this verification.

## 	[gemspec] ship all files in lib + README & LICENSE
Stop listing manually the files, and instead use Ruby to do the same. (file were missing because I didn't add them in the second commit)