### PR TITLE
Do an exact match of the check name when running tests

### DIFF
--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -346,7 +346,7 @@ namespace :ci do
       flavors_group = flavors.join('|')
       unless flavors.include?('default')
         tests_directory = tests_directory.reject do |test|
-          /.*(#{flavors_group}).*$/.match(test).nil?
+          /.*\/(#{flavors_group})\/.*$/.match(test).nil?
         end
       end
       # Rake on Windows doesn't support setting the var at the beginning of the

--- a/lib/tasks/ci/common.rb
+++ b/lib/tasks/ci/common.rb
@@ -346,7 +346,7 @@ namespace :ci do
       flavors_group = flavors.join('|')
       unless flavors.include?('default')
         tests_directory = tests_directory.reject do |test|
-          /.*\/(#{flavors_group})\/.*$/.match(test).nil?
+          %r{.*/(#{flavors_group})/.*$}.match(test).nil?
         end
       end
       # Rake on Windows doesn't support setting the var at the beginning of the


### PR DESCRIPTION
Without this, running `rake ci:run[cassandra]` would run the tests in the `cassandra` folder and also try to run the ones in the `cassandra_check` folder