### PR TITLE
Add `exec` task

### DIFF
--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -140,6 +140,15 @@ desc 'Check that requirements files are properly structured'
 task 'requirements_file' => ['ci:default:requirements_file'] do
 end
 
+desc 'Check that requirements files are properly structured'
+task 'requirements_file' => ['ci:default:requirements_file'] do
+end
+
+desc 'Execute command in SDK environment'
+task :exec, :command do |_, args|
+  exec(ENV, args[:command])
+end
+
 namespace :generate do
   desc 'Setup a development environment for the SDK'
   task :skeleton, :option do |_, args|

--- a/lib/tasks/sdk.rake
+++ b/lib/tasks/sdk.rake
@@ -140,10 +140,6 @@ desc 'Check that requirements files are properly structured'
 task 'requirements_file' => ['ci:default:requirements_file'] do
 end
 
-desc 'Check that requirements files are properly structured'
-task 'requirements_file' => ['ci:default:requirements_file'] do
-end
-
 desc 'Execute command in SDK environment'
 task :exec, :command do |_, args|
   exec(ENV, args[:command])


### PR DESCRIPTION
Allows running any command in the SDK environment.

## Example use case

I'm developing a check and want to run the mock tests only.
After having installed the deps of the check, I want to run the tests of that check quickly, fix them, iterate on them, etc.

With this new command, instead of doing a `rake ci:run[default]`, I can simply run:

```
$ source venv/bin/activate
$ bundle exec rake exec["nosetests <check_name>/test_<check_name>.py"]
```

and have my test results in just the time it takes for nose to run the tests.

We need to run `nosetests` in the SDK environment, otherwise the env variables are not set properly (the python path, the fixtures dir, etc, are not set correctly)