### PR TITLE
Adding required field to manifest

### DIFF
--- a/lib/config/manifest.json
+++ b/lib/config/manifest.json
@@ -7,6 +7,11 @@
   "short_description": "skeleton description.",
   "guid": "guid_replaceme",
   "support": "contrib",
+  "type":"check",
+  "doc_link": "link/to/the/dedicated/documentation/page",
   "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "categories":["list of categories","a complete list can be found on our documentation"],
+  "version": "0.1.0",
+  "is_public": true,
+  "has_logo": true
 }


### PR DESCRIPTION
We require more field from the manifest for documentation purposes:
* `doc_link`: a link to the dedicated documentation page
* `type`: can be `check`, `crawler`, or dogstatsD ; check is for `agent check`
*  `categories`: a list of categories, the complete list can be found here: https://docs-staging.datadoghq.com/gus/redesign/integrations/
* `is_public`: if set to true, the integration will be displayed and documented on our doc.
* `has_logo`: if set to true, we look for a logo in src/integrations_logo that has the same name as the integration in order to display it, if no logo is present, build tests will fail