### PR TITLE
add links to GitHub in gem metadata

### DIFF
--- a/datadog-sdk-testing.gemspec
+++ b/datadog-sdk-testing.gemspec
@@ -23,6 +23,12 @@ Gem::Specification.new do |s|
                      'README.md',
                      'LICENSE']
   s.homepage      = 'http://rubygems.org/gems/datadog-sdk-testing'
+  s.metadata      = {
+    'bug_tracker_uri'   => 'https://github.com/DataDog/datadog-sdk-testing/issues',
+    'changelog_uri'     => 'https://github.com/DataDog/datadog-sdk-testing/blob/master/CHANGELOG.md',
+    'documentation_uri' => 'https://github.com/DataDog/datadog-sdk-testing/blob/master/README.md',
+    'source_code_uri'   => 'https://github.com/DataDog/datadog-sdk-testing'
+  }
   s.license       = 'MIT'
   s.add_runtime_dependency 'colorize', '~> 0.8'
   s.add_runtime_dependency 'httparty', '~> 0.15'


### PR DESCRIPTION
Makes it easier to find the GitHub repo from RubyGems.

Not a huge PR but still please make sure I didn't break anything, I know nothing about Ruby.

Coded added has been copied from https://github.com/DataDog/dogapi-rb/blob/656e3260c01adac92f998f9f58993291efdc8a8b/dogapi.gemspec#L16 and adapted.